### PR TITLE
Fix build for NO_IRR_WAYLAND_DYNAMIC_LOAD_

### DIFF
--- a/source/Irrlicht/CIrrDeviceWayland.cpp
+++ b/source/Irrlicht/CIrrDeviceWayland.cpp
@@ -1704,6 +1704,7 @@ CIrrDeviceWayland::~CIrrDeviceWayland()
 
 bool CIrrDeviceWayland::initWayland()
 {
+#ifdef _IRR_WAYLAND_DYNAMIC_LOAD_
     do {
         if(!loadEglCoreFunctions()) {
             os::Printer::log("Couldn't load wayland egl core functions.", ELL_ERROR);
@@ -1728,6 +1729,7 @@ bool CIrrDeviceWayland::initWayland()
         clearWaylandFunctions();
         return false;
     }
+#endif
 
     m_display = pwl_display_connect(nullptr);
     

--- a/source/Irrlicht/org_kde_kwin_server_decoration_manager_client_protocol.cpp
+++ b/source/Irrlicht/org_kde_kwin_server_decoration_manager_client_protocol.cpp
@@ -22,6 +22,10 @@
 #ifdef _IRR_COMPILE_WITH_WAYLAND_DEVICE_
 #ifdef _IRR_WAYLAND_DYNAMIC_LOAD_
 #include "CWaylandProxyFunctionsWorkaround.h"
+#else
+#include <wayland-client-core.h>
+#include <wayland-client-protocol.h>
+#include <wayland-egl.h>
 #endif
 
 #include <stdlib.h>

--- a/source/Irrlicht/xdg_shell_protocol.cpp
+++ b/source/Irrlicht/xdg_shell_protocol.cpp
@@ -33,6 +33,10 @@
 #ifdef _IRR_COMPILE_WITH_WAYLAND_DEVICE_
 #ifdef _IRR_WAYLAND_DYNAMIC_LOAD_
 #include "CWaylandProxyFunctionsWorkaround.h"
+#else
+#include <wayland-client-core.h>
+#include <wayland-client-protocol.h>
+#include <wayland-egl.h>
 #endif
 
 #include <stdlib.h>

--- a/source/Irrlicht/zxdg_shell_unstable_v6_client_protocol.cpp
+++ b/source/Irrlicht/zxdg_shell_unstable_v6_client_protocol.cpp
@@ -31,6 +31,10 @@
 #ifdef _IRR_COMPILE_WITH_WAYLAND_DEVICE_
 #ifdef _IRR_WAYLAND_DYNAMIC_LOAD_
 #include "CWaylandProxyFunctionsWorkaround.h"
+#else
+#include <wayland-client-core.h>
+#include <wayland-client-protocol.h>
+#include <wayland-egl.h>
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
Patches required to get Irrlicht to compile with the following flags:
```
NO_IRR_WAYLAND_DYNAMIC_LOAD_
NO_IRR_DYNAMIC_OPENGL_
NO_IRR_DYNAMIC_OPENGL_ES_1_
NO_IRR_DYNAMIC_OPENGL_ES_2_
```

TODO:
---
- [ ] Investigate why this patch seems to make the build default to "static" Wayland and OpenGL with an untweaked `IrrCompileConfig.h`.